### PR TITLE
Remove restriction on score range in format checker for submission

### DIFF
--- a/codalab/competition_bundle/scoring_program/format_checker_for_submission.py
+++ b/codalab/competition_bundle/scoring_program/format_checker_for_submission.py
@@ -48,14 +48,9 @@ def check_format_for_ranking_submission(submission):
 
     for rating_str in submission["Rating"]:
         try:
-            rating = float(rating_str)
+            float(rating_str)
         except ValueError:
             raise ValueError("Rating {} is not a float.".format(rating_str))
-        else:
-            if 1 > rating or rating > 5:
-                raise ValueError(
-                    "Rating {} is not within the range between 1 and 5.".format(rating)
-                )
 
 
 def check_format_for_classification_submission(submission):


### PR DESCRIPTION
Previously, the format checker for a ranking submission raised an exception if a score was not in the range between 1 and 5.
That might not always be the case and is not really a reasonable requirement, so this pull request simply removes it.